### PR TITLE
#HOTFIX: boost::STATIC_ASSERTION_FAILURE  (boost >1.37)

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2013-2014 Dogecoin Developers
@@ -239,8 +240,8 @@ Value listunspent(const Array& params, bool fHelp)
         {
             CTxDestination address;
             if (ExtractDestination(pk, address))
-            {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+            {   
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
Ubuntu 16.04.3 LTS (Xenial Xerus) + boost >1.37

typename boost::add_reference<T>::type = const CScriptID&]' rpcrawtransaction.cpp:243:77: required from here
/usr/include/boost/variant/get.hpp:178:5: error: invalid application of 'sizeof' to incomplete type 'boost::STATIC_ASSERTION_FAILURE<false>'
     BOOST_STATIC_ASSERT_MSG(
     ^
makefile.unix:187: recipe for target 'obj/rpcrawtransaction.o' failed
make: *** [obj/rpcrawtransaction.o] Error 1